### PR TITLE
Change the content type  for error response

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -174,3 +174,5 @@ pomExtra in ThisBuild :=
 //FindBugs settings
 
 findbugsReportType := Some(FindbugsReport.PlainHtml)
+
+connectInput in run := true

--- a/examples/src/main/resources/api/testApi.yaml
+++ b/examples/src/main/resources/api/testApi.yaml
@@ -81,7 +81,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -110,7 +110,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -133,7 +133,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -155,7 +155,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -177,7 +177,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -200,7 +200,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
                 example: invalid.peer.address | invalid.json
@@ -221,7 +221,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -242,7 +242,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -272,7 +272,7 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string
 
@@ -300,6 +300,6 @@ paths:
         default:
           description: Error
           content:
-            text/plain; charset=UTF-8:
+            application/json:
               schema:
                 type: string

--- a/src/main/scala/scorex/core/api/client/ApiClient.scala
+++ b/src/main/scala/scorex/core/api/client/ApiClient.scala
@@ -24,7 +24,7 @@ class ApiClient(settings: RESTApiSettings) {
       } else ""
 
       // fixme: magic string "http://127.0.0.1:" should come from settings.
-      // fixme: Shouldn' we use the address from the bind address instead of 127.0.0.1?
+      // fixme: Shouldn't we use the address from the bind address instead of 127.0.0.1?
       val url = new URL("http://127.0.0.1:" + settings.bindAddress.getPort + "/" + path)
       val connection = url.openConnection().asInstanceOf[HttpURLConnection]
       connection.setRequestMethod(method)

--- a/src/main/scala/scorex/core/api/http/ApiError.scala
+++ b/src/main/scala/scorex/core/api/http/ApiError.scala
@@ -1,6 +1,6 @@
 package scorex.core.api.http
 
-import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCode, StatusCodes}
 import akka.http.scaladsl.server.{Directives, Route}
 
 import scala.language.implicitConversions
@@ -12,8 +12,9 @@ case class ApiError(statusCode: StatusCode, reason: String = "") {
 
   def complete(detail: String = ""): Route = {
     val nonEmptyReason = if (reason.isEmpty) statusCode.reason else reason
-    val body = if (detail.isEmpty) nonEmptyReason else s"$nonEmptyReason $detail"
-    Directives.complete(statusCode.intValue() -> body)
+    val result = if (detail.isEmpty) nonEmptyReason else s"$nonEmptyReason $detail"
+    val httpEntity = HttpEntity(ContentTypes.`application/json`, result)
+    Directives.complete(statusCode.intValue() -> httpEntity)
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/ScorexFoundation/Scorex/issues/304
![image](https://user-images.githubusercontent.com/10568673/44311894-c3c2ce00-a421-11e8-83cd-e45cf5a0e563.png)


@mike-aksarin Can you give me more context about the change `Override default akka http error handling`?